### PR TITLE
Modify menu behaviour

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,6 @@
 <ion-app>
-  <ion-split-pane contentId="main-content" [disabled]="isSplitViewDisabled">
+  <!-- Disable split view for all device types: -->
+  <ion-split-pane contentId="main-content" [disabled]="true"> 
 
     <ion-menu side="start" [disabled]="isMenuDisabled">
       <ion-header>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,7 +2,7 @@
   <!-- Disable split view for all device types: -->
   <ion-split-pane contentId="main-content" [disabled]="true"> 
 
-    <ion-menu side="start" [disabled]="isMenuDisabled">
+    <ion-menu side="start">
       <ion-header>
         <ion-toolbar color="primary">
           <!-- <ion-icon slot="start" name="calendar" ></ion-icon> -->

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -118,7 +118,6 @@ export class AppComponent implements OnInit {
   //   }
   // ];
   loggedIn = false;
-  isSplitViewDisabled = true;
   isMenuDisabled = true;
 
   constructor(
@@ -153,7 +152,6 @@ export class AppComponent implements OnInit {
       this.global.isDevice = this.platform.is('cordova');
 
       this.isMenuDisabled = false || environment.production;
-      this.isSplitViewDisabled = false || environment.production;
     });
   }
 
@@ -173,7 +171,6 @@ export class AppComponent implements OnInit {
     this.events.subscribe('user:login', () => {
       this.updateLoggedInStatus(true);
 
-      this.isSplitViewDisabled = false;
       this.isMenuDisabled = false;
     });
 
@@ -184,7 +181,6 @@ export class AppComponent implements OnInit {
     this.events.subscribe('user:logout', () => {
       this.updateLoggedInStatus(false);
 
-      this.isSplitViewDisabled = true;
       this.isMenuDisabled = true;
     });
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -118,7 +118,6 @@ export class AppComponent implements OnInit {
   //   }
   // ];
   loggedIn = false;
-  isMenuDisabled = true;
 
   constructor(
     private events: Events,
@@ -150,8 +149,6 @@ export class AppComponent implements OnInit {
       // this.network.initializeNetworkEvents();
 
       this.global.isDevice = this.platform.is('cordova');
-
-      this.isMenuDisabled = false || environment.production;
     });
   }
 
@@ -170,8 +167,6 @@ export class AppComponent implements OnInit {
   listenForLoginEvents() {
     this.events.subscribe('user:login', () => {
       this.updateLoggedInStatus(true);
-
-      this.isMenuDisabled = false;
     });
 
     this.events.subscribe('user:signup', () => {
@@ -180,8 +175,6 @@ export class AppComponent implements OnInit {
 
     this.events.subscribe('user:logout', () => {
       this.updateLoggedInStatus(false);
-
-      this.isMenuDisabled = true;
     });
   }
 

--- a/src/app/pages/login/login.ts
+++ b/src/app/pages/login/login.ts
@@ -74,6 +74,9 @@ export class LoginPage implements OnInit {
   }
 
   ionViewWillEnter() {
+
+    this.menu.enable(false);
+
     this.userData.getUsername().then((username) => {
       if (username) {
         this.login.username = username;
@@ -85,7 +88,9 @@ export class LoginPage implements OnInit {
     this.handleLogoCollision(this.logo, this.loginButton);
   }
 
-  ionViewDidLeave() { }
+  ionViewDidLeave() { 
+    this.menu.enable(true);    
+  }
 
   async onLogin(form: NgForm) {
 


### PR DESCRIPTION
Simplify menu enable/disable logic to match ionic-conference sample: disable on entering login screen, and enable on leaving. This solves a bug in the iPhone emulator, in which the menu is not deterministically hidden/shown as expected.